### PR TITLE
Fix #51

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 pkg_name = 'nanonet'
 pkg_path = os.path.join(os.path.dirname(__file__), pkg_name)
 verstrline = open(os.path.join(pkg_path, '__init__.py'), 'r').read()
+pkg_path = os.path.relpath(pkg_name)
 vsre = r"^__version__ = ['\"]([^'\"]*)['\"]"
 mo = re.search(vsre, verstrline, re.M)
 if mo:


### PR DESCRIPTION
Changing setup.py pkg_path from absolute to relative fixes this issue. 

Confirmed working on `Linux 4.9.0-2-amd64 #1 SMP Debian 4.9.18-1 (2017-03-30) x86_64 GNU/Linux`. Tested using `git clone git@github.com:cgmcintyr/nanonet.git && zip -r nanonet.zip nanonet && pip2 install --user nanonet.zip` command.